### PR TITLE
[back] refactor: native query 테이블 명 일치 및 예선 접수증 폰트 수정

### DIFF
--- a/back/src/main/java/com/example/cpsplatform/contest/Contest.java
+++ b/back/src/main/java/com/example/cpsplatform/contest/Contest.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@SQLDelete(sql = "UPDATE Contest SET deleted = true WHERE id=?")
+@SQLDelete(sql = "UPDATE contest SET deleted = true WHERE id=?")
 @SQLRestriction("deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Contest extends BaseEntity {

--- a/back/src/main/java/com/example/cpsplatform/file/domain/File.java
+++ b/back/src/main/java/com/example/cpsplatform/file/domain/File.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
-@SQLDelete(sql = "UPDATE File SET deleted = true WHERE id=?")
+@SQLDelete(sql = "UPDATE file SET deleted = true WHERE id=?")
 @SQLRestriction("deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class File extends BaseEntity {

--- a/back/src/main/java/com/example/cpsplatform/file/repository/FileRepository.java
+++ b/back/src/main/java/com/example/cpsplatform/file/repository/FileRepository.java
@@ -42,6 +42,6 @@ public interface FileRepository extends JpaRepository<File,Long>, FileRepository
 
 
     @Modifying
-    @Query(value = "delete from File where id in :fileIds",nativeQuery = true)
+    @Query(value = "delete from file where id in :fileIds",nativeQuery = true)
     void hardDeleteAllByIdIn(@Param("fileIds")List<Long> fileIds);
 }

--- a/back/src/main/java/com/example/cpsplatform/memberteam/domain/MemberTeam.java
+++ b/back/src/main/java/com/example/cpsplatform/memberteam/domain/MemberTeam.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "Member_team")
+@Table(name = "member_team")
 public class MemberTeam extends BaseEntity{
 
     @Id

--- a/back/src/main/java/com/example/cpsplatform/memberteam/repository/MemberTeamRepository.java
+++ b/back/src/main/java/com/example/cpsplatform/memberteam/repository/MemberTeamRepository.java
@@ -39,6 +39,6 @@ public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
     boolean existsByTeamIdAndLoginId(@Param("teamId") Long teamId, @Param("loginId") String loginId);
 
     @Modifying
-    @Query(value = "delete from MemberTeam where id in :memberTeamIds",nativeQuery = true)
+    @Query(value = "delete from member_team where id in :memberTeamIds",nativeQuery = true)
     void hardDeleteAllByIdIn(@Param("memberTeamIds") List<Long> memberTeamIds);
 }

--- a/back/src/main/resources/templates/certificate/preliminary-certificate.html
+++ b/back/src/main/resources/templates/certificate/preliminary-certificate.html
@@ -84,7 +84,7 @@
         </tr>
         <tr>
             <th>접수 번호</th><td th:text="${teamNumber}">001</td>
-            <th>접수 시간</th><td th:text="${registrationDate}">2025.05.06 16:23</td>
+            <th>접수 시간</th><td th:text="${registrationDate}" style="font-size: 15px">2025년 5월 15일 16:23</td>
         </tr>
     </table>
 

--- a/back/src/test/java/com/example/cpsplatform/contest/admin/service/ContestAdminServiceTest.java
+++ b/back/src/test/java/com/example/cpsplatform/contest/admin/service/ContestAdminServiceTest.java
@@ -171,7 +171,7 @@ class ContestAdminServiceTest {
     }
 
     @Transactional
-    @DisplayName("수정할 대회가 존재하지 않으면 예외가 발생한다.")
+    @DisplayName("대회를 임시 삭제한다.")
     @Test
     void deleteContest(){
         //given


### PR DESCRIPTION
## 작업 내용
- native query에서 실제 테이블 이름(`member_team`, `contest` 등)과 일치하도록 수정
- 예선 접수증에서 접수 시간의 폰트가 작게 나오는 문제 수정 (NanumGothic 폰트 크기 조정)

## 기타
- PDF 생성 시 Jar 내 static 폴더 경로 문제로 인한 FileNotFoundException 대응은 별도 PR에서 처리 예정
