### PR TITLE
[back] feat: 유니크 제약 조건 위반 예외 처리 및 테스트 추가

### DIFF
--- a/back/src/main/java/com/example/cpsplatform/auth/service/RegisterService.java
+++ b/back/src/main/java/com/example/cpsplatform/auth/service/RegisterService.java
@@ -34,13 +34,7 @@ public class RegisterService {
                 request.getEmail(), request.getEmail(), "signup_verify");
 
         if(result){
-            //인증 코드가 적절한 경우
-            try {
-                //todo 회원 중복 예외 다른방식으로 처리 요함
-                memberService.save(request.toMemberSaveDto());
-            } catch (DataIntegrityViolationException e){
-                throw new DuplicateDataException("중복된 회원이 존재합니다.");
-            }
+            memberService.save(request.toMemberSaveDto());
         }
     }
 

--- a/back/src/main/java/com/example/cpsplatform/certificate/domain/Certificate.java
+++ b/back/src/main/java/com/example/cpsplatform/certificate/domain/Certificate.java
@@ -12,7 +12,10 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "team_id","preliminary_contest_id","certificate_type"}))
+@Table( name = "certificate",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_preliminary_certificate", columnNames = {"member_id", "team_id", "preliminary_contest_id", "certificate_type"})
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Certificate extends BaseEntity {
 

--- a/back/src/main/java/com/example/cpsplatform/contest/Contest.java
+++ b/back/src/main/java/com/example/cpsplatform/contest/Contest.java
@@ -15,6 +15,9 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Table(name = "contest", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_contest_season", columnNames = {"season"})
+})
 @SQLDelete(sql = "UPDATE contest SET deleted = true WHERE id=?")
 @SQLRestriction("deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,7 +33,7 @@ public class Contest extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column(nullable = false,unique = true)
+    @Column(nullable = false)
     private int season;
 
     @Column(nullable = false,name = "registration_start_at")

--- a/back/src/main/java/com/example/cpsplatform/contest/admin/controller/ContestAdminController.java
+++ b/back/src/main/java/com/example/cpsplatform/contest/admin/controller/ContestAdminController.java
@@ -49,24 +49,14 @@ public class ContestAdminController {
     @AdminLog
     @PostMapping
     public ApiResponse<Object> createContest(@Valid @RequestBody CreateContestRequest request){
-        try{
-            //todo 추후 데이터 중복 예외 일괄 처리 요함
-            contestAdminService.createContest(request.toContestCreateDto());
-        } catch (DataIntegrityViolationException e){
-            throw new DuplicateDataException("동일한 회의 대회가 있습니다.");
-        }
+        contestAdminService.createContest(request.toContestCreateDto());
         return ApiResponse.ok(null);
     }
 
     @AdminLog
     @PutMapping
     public ApiResponse<Object> updateContest(@Valid @RequestBody UpdateContestRequest request){
-        try{
-            //todo 추후 데이터 중복 예외 일괄 처리 요함
-            contestAdminService.updateContest(request.toContestUpdateDto());
-        } catch (DataIntegrityViolationException e){
-            throw new DuplicateDataException("동일한 회의 대회가 있습니다.");
-        }
+        contestAdminService.updateContest(request.toContestUpdateDto());
         return ApiResponse.ok(null);
     }
 

--- a/back/src/main/java/com/example/cpsplatform/exception/controller/dto/UniqueConstraintMessage.java
+++ b/back/src/main/java/com/example/cpsplatform/exception/controller/dto/UniqueConstraintMessage.java
@@ -1,0 +1,64 @@
+package com.example.cpsplatform.exception.controller.dto;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Getter
+@RequiredArgsConstructor
+public enum UniqueConstraintMessage {
+
+    //Certificate 관련 제약조건
+    CERTIFICATE_UNIQUE("uk_preliminary_certificate", "이미 발급된 인증서입니다."),
+
+    //Contest 관련 제약조건
+    CONTEST_SEASON("uk_contest_season", "해당 시즌의 대회가 이미 존재합니다."),
+
+    //File 관련 제약조건
+    FILE_TEAM_SOLVE("uk_file_team_solve_id", "팀 솔루션에 이미 파일이 등록되어 있습니다."),
+
+    //Member 관련 제약조건
+    MEMBER_LOGIN_ID("uk_member_login_id", "이미 사용 중인 로그인 아이디입니다."),
+    MEMBER_EMAIL("uk_member_email", "이미 사용 중인 이메일 주소입니다."),
+    MEMBER_PHONE("uk_member_phone_number", "이미 등록된 전화번호입니다."),
+    MEMBER_ORGANIZATION("uk_member_organization_id", "이미 연결된 조직이 있습니다."),
+
+    //MemberTeam 관련 제약조건
+    MEMBER_TEAM("uk_member_team_memberid_teamid", "이미 해당 팀에 등록된 회원입니다."),
+
+    //Problem 관련 제약조건
+    PROBLEM_SECTION_ORDER("uk_problem_contest_section_order", "해당 대회의 섹션에 이미 같은 순서의 문제가 존재합니다."),
+    PROBLEM_TITLE("uk_problem_title", "이미 사용 중인 문제 제목입니다."),
+
+    //Team 관련 제약조건
+    TEAM_CONTEST_NUMBER("uk_team_contestid_number", "해당 대회에 이미 같은 번호의 팀이 존재합니다."),
+    TEAM_NAME("uk_team_name", "이미 사용 중인 팀 이름입니다."),
+
+    //TeamNumber 관련 제약조건
+    TEAM_NUMBER_CONTEST("uk_team_number_contestid", "해당 대회의 팀 번호가 이미 등록되어 있습니다."),
+
+    //TeamSolve 관련 제약조건
+    TEAM_SOLVE_PROBLEM("uk_team_solve_teamid_problemid", "해당 팀이 이미 이 문제에 대한 솔루션을 제출했습니다.");
+
+    private final String constraintName;
+    private final String message;
+    private static final Map<String,String> messageMap = Arrays.stream(UniqueConstraintMessage.values()).collect(
+            Collectors.toMap(UniqueConstraintMessage::getConstraintName, UniqueConstraintMessage::getMessage)
+    );
+
+    public static String findUniqueConstraintMessage(String constraintName) {
+        String message = messageMap.get(constraintName);
+        if (message == null) {
+            log.warn("정의되지 않은 제약조건 이름: {}", constraintName);
+            return "중복된 데이터가 존재합니다";
+        }
+        return message;
+    }
+
+}

--- a/back/src/main/java/com/example/cpsplatform/file/domain/File.java
+++ b/back/src/main/java/com/example/cpsplatform/file/domain/File.java
@@ -14,6 +14,9 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
+@Table(name = "file", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_file_team_solve_id", columnNames = {"team_solve_id"})
+})
 @SQLDelete(sql = "UPDATE file SET deleted = true WHERE id=?")
 @SQLRestriction("deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/back/src/main/java/com/example/cpsplatform/member/domain/Member.java
+++ b/back/src/main/java/com/example/cpsplatform/member/domain/Member.java
@@ -21,6 +21,12 @@ import java.time.Year;
 
 @Entity
 @Getter
+@Table(name = "member", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_member_login_id", columnNames = {"login_id"}),
+        @UniqueConstraint(name = "uk_member_email", columnNames = {"email"}),
+        @UniqueConstraint(name = "uk_member_phone_number", columnNames = {"phone_number"}),
+        @UniqueConstraint(name = "uk_member_organization_id", columnNames = {"organization_id"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
@@ -28,7 +34,7 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "login_id",nullable = false,unique = true,updatable = false,length = 12)
+    @Column(name = "login_id",nullable = false,updatable = false,length = 12)
     private String loginId;
 
     @Column(name = "password",nullable = false)
@@ -37,7 +43,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String name;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, name = "email")
     private String email;
 
     @Column(length = 20, nullable = false)
@@ -54,10 +60,11 @@ public class Member extends BaseEntity {
     @Embedded
     private Address address;
 
-    @Column(nullable = false, name = "phone_number", unique = true)
+    @Column(nullable = false, name = "phone_number")
     private String phoneNumber;
 
     @OneToOne(fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "organization_id")
     private Organization organization;
 
     @Builder

--- a/back/src/main/java/com/example/cpsplatform/memberteam/domain/MemberTeam.java
+++ b/back/src/main/java/com/example/cpsplatform/memberteam/domain/MemberTeam.java
@@ -3,14 +3,7 @@ package com.example.cpsplatform.memberteam.domain;
 import com.example.cpsplatform.BaseEntity;
 import com.example.cpsplatform.member.domain.Member;
 import com.example.cpsplatform.team.domain.Team;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +12,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "member_team")
+@Table(name = "member_team", uniqueConstraints =
+        @UniqueConstraint(name = "uk_member_team_memberid_teamid", columnNames = {"member_id","team_id"})
+)
 public class MemberTeam extends BaseEntity{
 
     @Id

--- a/back/src/main/java/com/example/cpsplatform/notice/domain/Notice.java
+++ b/back/src/main/java/com/example/cpsplatform/notice/domain/Notice.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 @Entity
 @Getter
+@Table(name = "notice")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notice extends BaseEntity {
 

--- a/back/src/main/java/com/example/cpsplatform/problem/domain/Problem.java
+++ b/back/src/main/java/com/example/cpsplatform/problem/domain/Problem.java
@@ -17,9 +17,11 @@ import java.util.Set;
 @Entity
 @Getter
 @Table(
+        name = "problem",uniqueConstraints = {
         //ex) 16회 대회에 초/중 섹션에 1번 문제가 복수일 경우를 유니크 제약 위반
-        uniqueConstraints = @UniqueConstraint(columnNames = {"contest_id", "section", "problem_order"})
-)
+        @UniqueConstraint(name = "uk_problem_contest_section_order", columnNames = {"contest_id", "section", "problem_order"}),
+        @UniqueConstraint(name = "uk_problem_title",columnNames = "title")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Problem extends BaseEntity {
 
@@ -27,7 +29,7 @@ public class Problem extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true,name = "title")
     private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -35,6 +37,7 @@ public class Problem extends BaseEntity {
     private Contest contest;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "section")
     private Section section;
 
     @Column

--- a/back/src/main/java/com/example/cpsplatform/team/domain/Team.java
+++ b/back/src/main/java/com/example/cpsplatform/team/domain/Team.java
@@ -18,14 +18,17 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"contest_id", "team_number"}))
+@Table(name = "team",uniqueConstraints = {
+    @UniqueConstraint(name = "uk_team_contestid_number",columnNames = {"contest_id", "team_number"}),
+    @UniqueConstraint(name = "uk_team_name",columnNames = {"name"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 100, name = "name")
     private String name;
 
     @Column(nullable = false)

--- a/back/src/main/java/com/example/cpsplatform/teamnumber/domain/TeamNumber.java
+++ b/back/src/main/java/com/example/cpsplatform/teamnumber/domain/TeamNumber.java
@@ -10,6 +10,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "team_number",uniqueConstraints =
+        @UniqueConstraint(name = "uk_team_number_contestid",columnNames = "contest_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamNumber {
     @Id
@@ -17,7 +20,7 @@ public class TeamNumber {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "contest_id", unique = true, nullable = false)
+    @JoinColumn(name = "contest_id", nullable = false)
     private Contest contest;
 
     @Column(nullable = false)

--- a/back/src/main/java/com/example/cpsplatform/teamsolve/domain/TeamSolve.java
+++ b/back/src/main/java/com/example/cpsplatform/teamsolve/domain/TeamSolve.java
@@ -11,7 +11,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "team_solve")
+@Table(name = "team_solve",uniqueConstraints =
+       @UniqueConstraint(name = "uk_team_solve_teamid_problemid",columnNames = {"team_id","problem_id"})
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamSolve extends BaseEntity {
 
@@ -20,11 +22,11 @@ public class TeamSolve extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(nullable = false,name = "team_id")
     private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(nullable = false,name = "problem_id")
     private Problem problem;
 
     private String content;

--- a/back/src/test/java/com/example/cpsplatform/exception/controller/GlobalExceptionHandlerTest.java
+++ b/back/src/test/java/com/example/cpsplatform/exception/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,98 @@
+package com.example.cpsplatform.exception.controller;
+
+import com.example.cpsplatform.contest.Contest;
+import com.example.cpsplatform.contest.admin.request.CreateContestRequest;
+import com.example.cpsplatform.contest.repository.ContestRepository;
+import com.example.cpsplatform.exception.controller.dto.UniqueConstraintMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static com.example.cpsplatform.exception.controller.dto.UniqueConstraintMessage.CONTEST_SEASON;
+import static java.time.LocalDateTime.now;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    ContestRepository contestRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @WithMockUser(roles = {"ADMIN"})
+    @DisplayName("중복된 시즌의 대회를 저장할 때, 유니크 제약 위반으로 예외가 발생한다.")
+    @Test
+    void CONTEST_SEASON() throws Exception {
+        //given
+        Contest contest = Contest.builder()
+                .title("테스트 대회")
+                .description("테스트 대회 설명")
+                .season(16)
+                .registrationStartAt(now().minusDays(5))
+                .registrationEndAt(now().minusDays(1))
+                .startTime(now())
+                .endTime(now().plusDays(1))
+                .build();
+        contestRepository.save(contest);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        LocalDateTime now = LocalDateTime.now();
+        CreateContestRequest request = new CreateContestRequest(
+                "테스트 대회",
+                16,
+                "테스트 대회 설명",
+                now.plusDays(1),
+                now.plusDays(2),
+                now.plusDays(3),
+                now.plusDays(4)
+        );
+
+        String content = objectMapper.writeValueAsString(request);
+
+        //when
+        //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.post("/api/admin/contests")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(content)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value(CONTEST_SEASON.getMessage()))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    //todo 추후에 모든 유니크 제약 테스트 작성
+
+}


### PR DESCRIPTION
[back] feat: 유니크 제약 조건 위반 예외 처리 및 테스트 추가

- DataIntegrityViolationException 발생 시 제약 조건 이름을 추출하여 사용자 친화적인 메시지를 반환하도록 리팩터링
  - UniqueConstraint enum을 통해 constraintName에 따라 메시지를 매핑
  - 제약 조건 이름이 없을 경우 기본 메시지("중복된 데이터가 존재합니다.") 반환

- 유니크 제약조건 예외 처리에 대한 통합 테스트 추가
  - 중복된 대회의 시즌 사용하여 저장 시 예외 발생을 유도하고,
    해당 에러 메시지가 API 응답에 포함되는지 검증
